### PR TITLE
Remove constraint for maximum aws provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.74.0"
+      version = ">= 3.74.0"
     }
   }
 }


### PR DESCRIPTION
This module is super handy, but I can't use it as the provider version conflicts with my own root aws provider version (4.x).

Changing to just having a minimum version fixes this and is recommended by terraform:

> Do not use ~> (or other maximum-version constraints) for modules you intend to reuse across many configurations, even if you know the module isn't compatible with certain newer versions. Doing so can sometimes prevent errors, but more often it forces users of the module to update many modules simultaneously when performing routine upgrades. Specify a minimum version, document any known incompatibilities, and let the root module manage the maximum version.

https://developer.hashicorp.com/terraform/language/providers/requirements#best-practices-for-provider-versions